### PR TITLE
Add user agent to SDO API requests

### DIFF
--- a/.github/actions/update-scrum-classes-on-ghost/action.yml
+++ b/.github/actions/update-scrum-classes-on-ghost/action.yml
@@ -4,6 +4,9 @@ inputs:
   trainer_id:  
     description: 'Id of the trainer'
     required: true
+  user_agent:
+    description: 'User agent to use for the API request'
+    required: true
   ghost_token:
     description: 'Ghost API token'
     required: true
@@ -14,6 +17,9 @@ runs:
     - run: |
         $trainerId = $env:trainerId
         $token = $env:token
+        $searchHeaders = @{
+            "User-Agent" = $env:userAgent
+        }
         
         Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
         Install-Module -Name JWT -force
@@ -34,7 +40,7 @@ runs:
               $body = @{ trainerId   = "$trainerId" } 
             }
             
-            $classes = Invoke-RestMethod -Uri "https://www.scrum.org/api/class-search" -Method POST -Body ($body | ConvertTo-Json)
+            $classes = Invoke-RestMethod -Uri "https://www.scrum.org/api/class-search" -Headers $searchHeaders -Method POST -Body ($body | ConvertTo-Json)
 
             if ($classes.items.Length -gt 0) {
                 $markdown = "`n| Course | Dates | Language | Location |`n|--------|-------|----------|----------|`n"
@@ -87,6 +93,7 @@ runs:
         $headers = @{
             Authorization  = "Ghost $jwttoken"
             "Content-Type" = "application/json"
+            "User-Agent" = $env:userAgent
         }
 
         $alltrainingpages = Invoke-RestMethod -Uri "https://scrumbug.ghost.io/ghost/api/admin/pages/" -Method GET -Headers $headers
@@ -140,3 +147,4 @@ runs:
       env:
         trainerId: ${{ inputs.trainer_id }}
         token: ${{ inputs.ghost_token }}
+        userAgent: ${{ inputs.user_agent }}

--- a/.github/actions/update-scrum-classes/action.yml
+++ b/.github/actions/update-scrum-classes/action.yml
@@ -4,12 +4,19 @@ inputs:
   trainer_id:  
     description: 'Id of the trainer'
     required: true
+  user_agent:
+    description: 'User agent to use for the API request'
+    required: true
 
 runs:
   using: "composite"
   steps:
     - run: |
-        $classes = Invoke-RestMethod -Uri "https://www.scrum.org/api/class-search" -Method POST -Body (@{ 
+        $headers = @{
+            "User-Agent" = ${{ inputs.user_agent }}
+        }
+
+        $classes = Invoke-RestMethod -Uri "https://www.scrum.org/api/class-search" -Headers $headers -Method POST -Body (@{ 
                 trainerId = "${{ inputs.trainer_id }}"
             } | ConvertTo-Json)
 

--- a/.github/workflows/scrum-classes-workflow.yml
+++ b/.github/workflows/scrum-classes-workflow.yml
@@ -15,6 +15,7 @@ jobs:
         uses: jessehouwing/jessehouwing/.github/actions/update-scrum-classes@main
         with:
           trainer_id: 76
+          user_agent: 'JesseHouwingScript'
   update-blog-with-scrumclasses:
     runs-on: ubuntu-latest
     name: Update Ghost Blog
@@ -23,4 +24,5 @@ jobs:
         uses: jessehouwing/jessehouwing/.github/actions/update-scrum-classes-on-ghost@main
         with:
           trainer_id: 76
+          user_agent: 'JesseHouwingScript'
           ghost_token: ${{ secrets.GHOST_TOKEN }}


### PR DESCRIPTION
SDO is trying to get a sense for automation script usage for traffic troubleshooting purposes. While this script is not suspected of being the culprit, it's advantageous for them to identify these scripts in case security policies are changed.

- Pass a static `user-agent` value to GH actions. When the GH action is run, this value will be added to the `User-Agent` header for requests to the SDO API to help them precisely identify requests from this script.